### PR TITLE
Adds StringResolver interface plus default impl.

### DIFF
--- a/resourceholder2/build.gradle
+++ b/resourceholder2/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.0.8-beta'
     testCompile 'org.robolectric:robolectric:3.0-rc3'
+    compile 'org.jetbrains:annotations:15.0'
 }
 
 robolectric {

--- a/resourceholder2/src/main/java/se/gravlax/resourceholder/lib/LocalizableFactory.java
+++ b/resourceholder2/src/main/java/se/gravlax/resourceholder/lib/LocalizableFactory.java
@@ -1,16 +1,18 @@
 package se.gravlax.resourceholder.lib;
 
-import android.support.annotation.NonNull;
-
 import com.google.common.base.Preconditions;
+
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Generates LocalizedStrings.
  */
 public class LocalizableFactory {
 
-    public LocalizeableString create(@NonNull final String literal) {
+    public LocalizeableString create(@NotNull final String literal) {
         Preconditions.checkNotNull(literal);
         return new StringLiteral(literal);
     }
+
+
 }

--- a/resourceholder2/src/main/java/se/gravlax/resourceholder/lib/PluralStringResource.java
+++ b/resourceholder2/src/main/java/se/gravlax/resourceholder/lib/PluralStringResource.java
@@ -9,6 +9,7 @@ import com.google.common.base.Preconditions;
 
 public class PluralStringResource implements LocalizeableString{
     @PluralsRes private final int mPluralResourceId;
+    private boolean mBound = false;
     private int mCount;
 
     public PluralStringResource(@PluralsRes final int pluralResourceId) {
@@ -24,6 +25,7 @@ public class PluralStringResource implements LocalizeableString{
      */
     public void bindCount(final int i) {
         mCount = i;
+        mBound = true;
     }
 
 
@@ -32,6 +34,7 @@ public class PluralStringResource implements LocalizeableString{
     public String getString(@NonNull Context context) {
         final Resources resources = context.getResources();
         Preconditions.checkNotNull(resources);
+        Preconditions.checkArgument(mBound);
         return resources.getQuantityString(mPluralResourceId, mCount, mCount);
     }
 }

--- a/resourceholder2/src/main/java/se/gravlax/resourceholder/lib/StringResolver.java
+++ b/resourceholder2/src/main/java/se/gravlax/resourceholder/lib/StringResolver.java
@@ -1,0 +1,16 @@
+package se.gravlax.resourceholder.lib;
+
+import org.jetbrains.annotations.NotNull;
+
+public interface StringResolver {
+
+    /**
+     * Takes a localizable string, and supplying an Android context, it resolves that LocalizableString from a string resource to an
+     * actual string.
+     *
+     * @param localizeableString the LS to resolve
+     * @return The (if applicable) localized version of that LS as a string.
+     */
+    @NotNull
+    String resolve(@NotNull final LocalizeableString localizeableString);
+}

--- a/resourceholder2/src/main/java/se/gravlax/resourceholder/lib/WeakRefContextRetainingStringResolver.java
+++ b/resourceholder2/src/main/java/se/gravlax/resourceholder/lib/WeakRefContextRetainingStringResolver.java
@@ -1,0 +1,29 @@
+package se.gravlax.resourceholder.lib;
+
+import android.content.Context;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Default implementation of a string resolver, which retains a weak reference to the context it was created with.
+ * Will return "" for any resolution after the weak reference has lapsed.
+ */
+public class WeakRefContextRetainingStringResolver implements StringResolver {
+    private final WeakReference<Context> mContextRef;
+
+    public WeakRefContextRetainingStringResolver(@NotNull final  Context context) {
+        mContextRef = new WeakReference<>(context);
+    }
+
+    @NotNull
+    @Override
+    public String resolve(@NotNull LocalizeableString localizeableString) {
+        Context context = mContextRef.get();
+        if (context != null) {
+            return localizeableString.getString(context);
+        }
+        return ""; // TODO (atexit): should we throw instead?
+    }
+}

--- a/resourceholder2/src/test/java/se/gravlax/resourceholder/lib/StringResolverTest.java
+++ b/resourceholder2/src/test/java/se/gravlax/resourceholder/lib/StringResolverTest.java
@@ -1,0 +1,40 @@
+package se.gravlax.resourceholder.lib;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
+public class StringResolverTest {
+
+
+    private LocalizableFactory mLocalizableFactory;
+    private StringResolver mStringResolver;
+
+    @Before
+    public void setUp() throws Exception {
+        mLocalizableFactory = new LocalizableFactory();
+        mStringResolver = new WeakRefContextRetainingStringResolver(RuntimeEnvironment.application);
+    }
+
+    @Test
+    public void shouldResolveStringLiteral() {
+        String expectedOutput = "expected string literal";
+        LocalizeableString localizeableString = mLocalizableFactory.create(expectedOutput);
+        assertEquals(expectedOutput, mStringResolver.resolve(localizeableString));
+    }
+
+    @Test
+    public void shouldResolveQuantityString() {
+        PluralStringResource pluralStringResource = new PluralStringResource(R.plurals.plural_with_format_string);
+        pluralStringResource.bindCount(2);
+        String expectedResult = "2 two";
+        assertEquals(expectedResult, mStringResolver.resolve(pluralStringResource));
+    }
+}


### PR DESCRIPTION
In order to not actually leak Contexts, it is usually prudent to pass an
instance of StringResolver to presenters and models and similar,
allowing us to delegate any resolution back to e.g. the activity or
fragment, while still retaining the flexibility that passing around
LocalizableString:s gives us.

This commit also adds a default implementation that retains a context
through a weak reference, thus lowering the chance of us leaking a
context by being sloppy.